### PR TITLE
[Core] trigger event on clear

### DIFF
--- a/packages/core/src/core.ts
+++ b/packages/core/src/core.ts
@@ -449,6 +449,7 @@ export class Core {
     this.datePicked.length = 0;
     this.updateValues();
     this.renderAll();
+    this.trigger('clear');
   }
 
   /**

--- a/packages/range-plugin/src/index.ts
+++ b/packages/range-plugin/src/index.ts
@@ -307,6 +307,7 @@ export class RangePlugin extends BasePlugin implements IPlugin {
     this.picker.datePicked.length = 0;
     this.updateValues();
     this.picker.renderAll();
+    this.picker.trigger('clear');
   }
 
   /**


### PR DESCRIPTION
Hey @wakirin!

Pressing the reset button does not trigger the `selected` event nor any other event to hook in.

So I've added a `clear` event to hook into if needed (which I do)

Cheers Adrian