### PR TITLE
[AmpPlugin] Fix typeerror when setting options

### DIFF
--- a/packages/amp-plugin/src/interface.ts
+++ b/packages/amp-plugin/src/interface.ts
@@ -16,7 +16,7 @@ export interface IAmpPlugin extends IBaseConfig {
 }
 
 declare module '@easepick/core/dist/types' {
-  interface IAmpPlugin {
+  interface IPickerConfig {
     AmpPlugin?: IAmpPlugin;
   }
 }


### PR DESCRIPTION
Setting AmpPlugin options in an angular project causes error `'AmpPlugin' does not exist in type 'IPickerConfig'`.

I changed the interface name to fix it.