### PR TITLE
Disable hidePicker for when inline mode is enabled

### DIFF
--- a/packages/core/src/core.ts
+++ b/packages/core/src/core.ts
@@ -106,10 +106,10 @@ export class Core {
 
   /**
    * Add listener to container element
-   * 
-   * @param type 
-   * @param listener 
-   * @param options 
+   *
+   * @param type
+   * @param listener
+   * @param options
    */
   public on(type: string, listener: (event) => void, options: unknown = {}): void {
     this.ui.container.addEventListener(type, listener, options);
@@ -117,10 +117,10 @@ export class Core {
 
   /**
    * Remove listener from container element
-   * 
-   * @param type 
-   * @param listener 
-   * @param options 
+   *
+   * @param type
+   * @param listener
+   * @param options
    */
   public off(type: string, listener: (event) => void, options: unknown = {}): void {
     this.ui.container.removeEventListener(type, listener, options);
@@ -128,10 +128,10 @@ export class Core {
 
   /**
    * Dispatch an event
-   * 
-   * @param type 
-   * @param detail 
-   * @returns 
+   *
+   * @param type
+   * @param detail
+   * @returns
    */
   public trigger(type: string, detail: unknown = {}): boolean {
     return this.ui.container.dispatchEvent(new CustomEvent(type, { detail }));
@@ -156,8 +156,8 @@ export class Core {
 
   /**
    * Fired on render event
-   * 
-   * @param event 
+   *
+   * @param event
    */
   public onRender(event: CustomEvent) {
     const { view, date }: IEventDetail = event.detail;
@@ -175,8 +175,8 @@ export class Core {
   }
 
   /**
-   * 
-   * @param element 
+   *
+   * @param element
    */
   public onClickHeaderButton(element: HTMLElement) {
     if (this.isCalendarHeaderButton(element)) {
@@ -191,8 +191,8 @@ export class Core {
   }
 
   /**
-   * 
-   * @param element 
+   *
+   * @param element
    */
   public onClickCalendarDay(element: HTMLElement) {
     if (this.isCalendarDay(element)) {
@@ -215,8 +215,8 @@ export class Core {
   }
 
   /**
-   * 
-   * @param element 
+   *
+   * @param element
    */
   public onClickApplyButton(element: HTMLElement) {
     if (this.isApplyButton(element)) {
@@ -232,9 +232,9 @@ export class Core {
   }
 
   /**
-   * 
-   * @param element 
-   * @returns 
+   *
+   * @param element
+   * @returns
    */
   public onClickCancelButton(element: HTMLElement) {
     if (this.isCancelButton(element)) {
@@ -245,7 +245,7 @@ export class Core {
 
   /**
    * Fired on click event
-   * 
+   *
    * @param event
    */
   public onClick(event): void {
@@ -265,7 +265,7 @@ export class Core {
 
   /**
    * Determine if the picker is visible or not
-   * 
+   *
    * @returns Boolean
    */
   public isShown(): boolean {
@@ -275,8 +275,8 @@ export class Core {
 
   /**
    * Show the picker
-   * 
-   * @param event 
+   *
+   * @param event
    */
   public show(event?): void {
     if (this.isShown()) return;
@@ -306,8 +306,8 @@ export class Core {
 
   /**
    * Set date programmatically
-   * 
-   * @param date 
+   *
+   * @param date
    */
   public setDate(date: Date | string | number): void {
     const d = new DateTime(date, this.options.format);
@@ -321,7 +321,7 @@ export class Core {
   }
 
   /**
-   * 
+   *
    * @returns DateTime
    */
   public getDate(): DateTime {
@@ -363,8 +363,8 @@ export class Core {
   /**
    * Function for documentClick option
    * Allows the picker to close when the user clicks outside
-   * 
-   * @param e 
+   *
+   * @param e
    */
   public hidePicker(e): void {
     let target = e.target;
@@ -376,6 +376,7 @@ export class Core {
     }
 
     if (this.isShown()
+      && this.options.inline === false
       && host !== this.ui.wrapper
       && target !== this.options.element) {
       this.hide();
@@ -384,8 +385,8 @@ export class Core {
 
   /**
    * Render entire picker layout
-   * 
-   * @param date 
+   *
+   * @param date
    */
   public renderAll(date?: DateTime): void {
     this.trigger('render', { view: 'Container', date: (date || this.calendars[0]).clone() });
@@ -393,8 +394,8 @@ export class Core {
 
   /**
    * Determines if the element is buttons of header (previous month, next month)
-   * 
-   * @param element 
+   *
+   * @param element
    * @returns Boolean
    */
   public isCalendarHeaderButton(element: HTMLElement): boolean {
@@ -403,8 +404,8 @@ export class Core {
 
   /**
    * Determines if the element is day element
-   * 
-   * @param element 
+   *
+   * @param element
    * @returns Boolean
    */
   public isCalendarDay(element: HTMLElement): boolean {
@@ -413,8 +414,8 @@ export class Core {
 
   /**
    * Determines if the element is the apply button
-   * 
-   * @param element 
+   *
+   * @param element
    * @returns Boolean
    */
   public isApplyButton(element: HTMLElement): boolean {
@@ -423,8 +424,8 @@ export class Core {
 
   /**
    * Determines if the element is the cancel button
-   * 
-   * @param element 
+   *
+   * @param element
    * @returns Boolean
    */
   public isCancelButton(element: HTMLElement): boolean {
@@ -433,8 +434,8 @@ export class Core {
 
   /**
    * Change visible month
-   * 
-   * @param date 
+   *
+   * @param date
    */
   public gotoDate(date: Date | string | number): void {
     const toDate = new DateTime(date, this.options.format);
@@ -513,8 +514,8 @@ export class Core {
 
   /**
    * Calculate the position of the picker
-   * 
-   * @param element 
+   *
+   * @param element
    * @returns { top, left }
    */
   private adjustPosition(element: HTMLElement) {

--- a/packages/range-plugin/src/index.ts
+++ b/packages/range-plugin/src/index.ts
@@ -48,7 +48,7 @@ export class RangePlugin extends BasePlugin implements IPlugin {
 
   /**
    * Returns plugin name
-   * 
+   *
    * @returns String
    */
   public getName(): string {
@@ -312,8 +312,8 @@ export class RangePlugin extends BasePlugin implements IPlugin {
 
   /**
    * Function `show` event
-   * 
-   * @param event 
+   *
+   * @param event
    */
   private onShow(event) {
     const { target }: IEventDetail = event.detail;
@@ -329,8 +329,8 @@ export class RangePlugin extends BasePlugin implements IPlugin {
   /**
    * Function `view` event
    * Adds HTML layout of current plugin to the picker layout
-   * 
-   * @param event 
+   *
+   * @param event
    */
   private onView(event: CustomEvent) {
     const { view, target }: IEventDetail = event.detail;
@@ -373,8 +373,8 @@ export class RangePlugin extends BasePlugin implements IPlugin {
   /**
    * Function for documentClick option
    * Allows the picker to close when the user clicks outside
-   * 
-   * @param e 
+   *
+   * @param e
    */
   private hidePicker(e) {
     let target = e.target;
@@ -386,6 +386,7 @@ export class RangePlugin extends BasePlugin implements IPlugin {
     }
 
     if (this.picker.isShown()
+      && this.options.inline === false
       && host !== this.picker.ui.wrapper
       && target !== this.picker.options.element
       && target !== this.options.elementEnd) {
@@ -395,8 +396,8 @@ export class RangePlugin extends BasePlugin implements IPlugin {
 
   /**
    * Set startDate programmatically
-   * 
-   * @param date 
+   *
+   * @param date
    */
   private setStartDate(date: Date | string | number) {
     const d = new DateTime(date, this.picker.options.format);
@@ -409,8 +410,8 @@ export class RangePlugin extends BasePlugin implements IPlugin {
 
   /**
    * Set endDate programmatically
-   * 
-   * @param date 
+   *
+   * @param date
    */
   private setEndDate(date: Date | string | number) {
     const d = new DateTime(date, this.picker.options.format);
@@ -423,9 +424,9 @@ export class RangePlugin extends BasePlugin implements IPlugin {
 
   /**
    * Set date range programmatically
-   * 
-   * @param start 
-   * @param end 
+   *
+   * @param start
+   * @param end
    */
   private setDateRange(start: Date | string | number, end: Date | string | number) {
     const startDate = new DateTime(start, this.picker.options.format);
@@ -440,7 +441,7 @@ export class RangePlugin extends BasePlugin implements IPlugin {
   }
 
   /**
-   * 
+   *
    * @returns DateTime
    */
   private getStartDate(): DateTime {
@@ -448,8 +449,8 @@ export class RangePlugin extends BasePlugin implements IPlugin {
   }
 
   /**
-   * 
-   * @returns 
+   *
+   * @returns
    */
   private getEndDate(): DateTime {
     return this.options.endDate instanceof Date ? this.options.endDate.clone() : null;
@@ -457,8 +458,8 @@ export class RangePlugin extends BasePlugin implements IPlugin {
 
   /**
    * Handle `mouseenter` event
-   * 
-   * @param event 
+   *
+   * @param event
    */
   private onMouseEnter(event) {
     const target = event.target;
@@ -527,8 +528,8 @@ export class RangePlugin extends BasePlugin implements IPlugin {
 
   /**
    * Handle `mouseleave` event
-   * 
-   * @param event 
+   *
+   * @param event
    */
   private onMouseLeave(event) {
     if (this.isContainer(event.target) && this.options.repick) {
@@ -624,9 +625,9 @@ export class RangePlugin extends BasePlugin implements IPlugin {
 
   /**
    * Displays tooltip of selected days
-   * 
-   * @param element 
-   * @param text 
+   *
+   * @param element
+   * @param text
    */
   private showTooltip(element: HTMLElement, text: string) {
     this.tooltipElement.style.visibility = 'visible';
@@ -697,8 +698,8 @@ export class RangePlugin extends BasePlugin implements IPlugin {
 
   /**
    * Determines if the element is the picker container
-   *  
-   * @param element 
+   *
+   * @param element
    * @returns Boolean
    */
   private isContainer(element: HTMLElement): boolean {


### PR DESCRIPTION
We use the `view` event to catch a month change. But the `view` event is triggered every page click, also the click is not inside the picker. The `view` event is triggered because when you click somewhere in the page, the picker 'modal' has to hide. But we use the picker with `inline` mode enabled, so it is not necessary to hide the picker.

This code change will disable the hide function when `inline` mode is enabled.
Maybe also a solution for https://github.com/easepick/easepick/issues/129
