### PR TITLE
[Amp] Add `week` locale

### DIFF
--- a/packages/amp-plugin/README.md
+++ b/packages/amp-plugin/README.md
@@ -19,4 +19,4 @@ Adds extra options.
 | resetButton | boolean <br/> function | false | Adds a reset button to clear the current selection. It is allowed to pass a custom function that must return `true` to clear the selection.
 | darkMode | boolean | true | Allows dark mode to be used if the user's system settings are set to dark mode.
 | weekNumbers | boolean | false | Show week numbers.
-| locale | object | { resetButton: '<svg xmlns="http://www.w3.org/2000/svg" height="24" width="24"><path d="M13 3c-4.97 0-9 4.03-9 9H1l3.89 3.89.07.14L9 12H6c0-3.87 3.13-7 7-7s7 3.13 7 7-3.13 7-7 7c-1.93 0-3.68-.79-4.94-2.06l-1.42 1.42C8.27 19.99 10.51 21 13 21c4.97 0 9-4.03 9-9s-4.03-9-9-9zm-1 5v5l4.28 2.54.72-1.21-3.5-2.08V8H12z"/></svg>' } | Texts for Amp plugin options.
+| locale | object | { resetButton: '<svg xmlns="http://www.w3.org/2000/svg" height="24" width="24"><path d="M13 3c-4.97 0-9 4.03-9 9H1l3.89 3.89.07.14L9 12H6c0-3.87 3.13-7 7-7s7 3.13 7 7-3.13 7-7 7c-1.93 0-3.68-.79-4.94-2.06l-1.42 1.42C8.27 19.99 10.51 21 13 21c4.97 0 9-4.03 9-9s-4.03-9-9-9zm-1 5v5l4.28 2.54.72-1.21-3.5-2.08V8H12z"/></svg>', week: 'Wk' } | Texts for Amp plugin options.

--- a/packages/amp-plugin/src/index.ts
+++ b/packages/amp-plugin/src/index.ts
@@ -24,7 +24,8 @@ export class AmpPlugin extends BasePlugin implements IPlugin {
     },
     darkMode: true,
     locale: {
-      resetButton: `<svg xmlns="http://www.w3.org/2000/svg" height="24" width="24"><path d="M13 3c-4.97 0-9 4.03-9 9H1l3.89 3.89.07.14L9 12H6c0-3.87 3.13-7 7-7s7 3.13 7 7-3.13 7-7 7c-1.93 0-3.68-.79-4.94-2.06l-1.42 1.42C8.27 19.99 10.51 21 13 21c4.97 0 9-4.03 9-9s-4.03-9-9-9zm-1 5v5l4.28 2.54.72-1.21-3.5-2.08V8H12z"/></svg>`
+      resetButton: `<svg xmlns="http://www.w3.org/2000/svg" height="24" width="24"><path d="M13 3c-4.97 0-9 4.03-9 9H1l3.89 3.89.07.14L9 12H6c0-3.87 3.13-7 7-7s7 3.13 7 7-3.13 7-7 7c-1.93 0-3.68-.79-4.94-2.06l-1.42 1.42C8.27 19.99 10.51 21 13 21c4.97 0 9-4.03 9-9s-4.03-9-9-9zm-1 5v5l4.28 2.54.72-1.21-3.5-2.08V8H12z"/></svg>`,
+      week: 'Wk'
     },
   };
 
@@ -256,7 +257,7 @@ export class AmpPlugin extends BasePlugin implements IPlugin {
       if (view === 'CalendarDayNames') {
         const w = document.createElement('div');
         w.className = 'wnum-header';
-        w.innerHTML = 'Wk';
+        w.innerHTML = this.options.locale.week;
         target.prepend(w);
       }
 

--- a/packages/amp-plugin/src/interface.ts
+++ b/packages/amp-plugin/src/interface.ts
@@ -12,6 +12,7 @@ export interface IAmpPlugin extends IBaseConfig {
   weekNumbers?: boolean;
   locale?: {
     resetButton?: string;
+    week?: string;
   }
 }
 


### PR DESCRIPTION
## AmpPlugin
Add `week` to `locale` parameter.

![image](https://user-images.githubusercontent.com/25293190/223977959-1742ef8d-59a6-4b93-8db0-a630ebd4c73a.png)

Allow developers to add translation when using languages other than English (French: `Sem`)