### PR TITLE
Allow drop shadow to be configured using CSS vars

### DIFF
--- a/packages/core/src/scss/_container.scss
+++ b/packages/core/src/scss/_container.scss
@@ -33,7 +33,7 @@
     position: relative;
     top: 0px;
     left: 0px;
-    box-shadow: 0 7px 14px 0 rgba(65, 69, 88, 0.1), 0 3px 6px 0 rgba(0, 0, 0, 0.07);
+    box-shadow: 0 7px 14px 0 var(--color-drop-shadow-a), 0 3px 6px 0 var(--color-drop-shadow-b);
     height: auto;
     transform: scaleY(1);
   }

--- a/packages/core/src/scss/_host.scss
+++ b/packages/core/src/scss/_host.scss
@@ -28,6 +28,9 @@
   --color-border-default: #ddd;
   --color-border-locked: #f9f9f9;
 
+  --color-drop-shadow-a: rgba(65, 69, 88, 0.1);
+  --color-drop-shadow-b: rgba(0, 0, 0, 0.07);
+
   --day-width: 42px;
   --day-height: 37px;
   --border-radius: 2px;


### PR DESCRIPTION
Adds two CSS color variables to allow the drop shadow to be configured.

<img width="189" alt="Screenshot 2023-11-25 at 11 24 42 AM" src="https://github.com/easepick/easepick/assets/520550/bf1c4aa0-13be-415d-8f53-ca8ed876201a">
